### PR TITLE
Access ISO-639-1 language code without country code

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -19,6 +19,7 @@ var _iso31661Alpha2 = require('iso-3166-1-alpha-2');
 var _iso31661Alpha22 = _interopRequireDefault(_iso31661Alpha2);
 
 var REG = /^([a-z]{2})-([A-Z]{2})$/;
+var REG_LAN = /^([a-z]{2})$/;
 
 var LocaleCode = (function () {
   function LocaleCode() {
@@ -31,7 +32,10 @@ var LocaleCode = (function () {
     /* language iso-639-1 */
     value: function getLanguageCode(code) {
       var match = code.match(REG);
-      if (!match || match.length < 1) return '';
+      if (!match || match.length < 1) {
+        match = code.match(REG_LAN);
+        if (!match || match.length < 1) return '';
+      }
       return match[1];
     }
   }, {
@@ -78,20 +82,21 @@ var LocaleCode = (function () {
     key: 'getCountryCode',
     value: function getCountryCode(code) {
       var match = code.match(REG);
-      if (!match || match.length < 2) return '';
+      if (!match || match.length < 2) return null;
       return match[2];
     }
   }, {
     key: 'getCountryName',
     value: function getCountryName(code) {
       var countryCode = LocaleCode.getCountryCode(code);
+      if (!countryCode) return null;
       return _iso31661Alpha22['default'].getCountry(countryCode);
     }
   }, {
     key: 'validateCountryCode',
     value: function validateCountryCode(code) {
       code = LocaleCode.getCountryCode(code);
-      if (_iso31661Alpha22['default'].getCodes().indexOf(code) === -1) {
+      if (!code || _iso31661Alpha22['default'].getCodes().indexOf(code) === -1) {
         return false;
       } else {
         return true;
@@ -104,6 +109,8 @@ var LocaleCode = (function () {
     value: function validate(code) {
       var match = code.match(REG);
       if (match && match.length === 3 && LocaleCode.validateLanguageCode(code) && LocaleCode.validateCountryCode(code)) {
+        return true;
+      }if (code.match(REG_LAN) && code.match(REG_LAN).length === 2 && _iso6391Zh2['default'].validate(code)) {
         return true;
       } else {
         return false;

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,16 @@ import LanguageCode from 'iso-639-1-zh'
 import CountryCode from 'iso-3166-1-alpha-2'
 
 const REG = /^([a-z]{2})-([A-Z]{2})$/
+const REG_LAN = /^([a-z]{2})$/
 
 export default class LocaleCode {
   /* language iso-639-1 */
   static getLanguageCode(code) {
     var match = code.match(REG)
-    if(!match || match.length < 1) return ''
+    if(!match || match.length < 1) {
+      match = code.match(REG_LAN)
+      if (!match || match.length < 1) return ''
+    }
     return match[1]
   }
 
@@ -35,7 +39,7 @@ export default class LocaleCode {
     var list = []
     for (var i = 0; i < codes.length; i++) {
       list.push({
-        code:codes[i], 
+        code:codes[i],
         name: LocaleCode.getLanguageName(codes[i]),
         nativeName: LocaleCode.getLanguageNativeName(codes[i]),
         zhName: LocaleCode.getLanguageZhName(codes[i])
@@ -47,16 +51,17 @@ export default class LocaleCode {
   /* country iso-3166-1-alpha-2 */
   static getCountryCode(code) {
     var match = code.match(REG)
-    if(!match || match.length < 2) return ''
+    if(!match || match.length < 2) return null
     return match[2]
   }
   static getCountryName(code) {
     var countryCode = LocaleCode.getCountryCode(code)
+    if (!countryCode) return null
     return CountryCode.getCountry(countryCode)
   }
   static validateCountryCode(code) {
     code = LocaleCode.getCountryCode(code)
-    if(CountryCode.getCodes().indexOf(code) === -1) {
+    if(!code || CountryCode.getCodes().indexOf(code) === -1) {
       return false
     } else {
       return true
@@ -66,9 +71,11 @@ export default class LocaleCode {
   /* validate */
   static validate(code) {
     var match = code.match(REG)
-    if(match && match.length === 3 && 
+    if(match && match.length === 3 &&
       LocaleCode.validateLanguageCode(code) &&
       LocaleCode.validateCountryCode(code)) {
+      return true
+    } if(code.match(REG_LAN) && code.match(REG_LAN).length === 2 && LanguageCode.validate(code)) {
       return true
     } else {
       return false

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,9 @@ describe('getLanguageCode()', function() {
   it('zh-US', function(){
     assert.equal(LocaleCode.getLanguageCode('zh-CN'), 'zh')
   })
+  it('en', function(){
+    assert.equal(LocaleCode.getLanguageCode('en'), 'en')
+  })
 })
 
 describe('getLanguageName()', function() {
@@ -17,6 +20,9 @@ describe('getLanguageName()', function() {
   })
   it('zh-CN', function(){
     assert.equal(LocaleCode.getLanguageName('zh-CN'), 'Chinese')
+  })
+  it('en', function(){
+    assert.equal(LocaleCode.getLanguageName('en'), 'English')
   })
 })
 
@@ -27,6 +33,9 @@ describe('getLanguageNativeName()', function() {
   it('zh-CN', function(){
     assert.equal(LocaleCode.getLanguageNativeName('zh-CN'), '中文')
   })
+  it('en', function(){
+    assert.equal(LocaleCode.getLanguageNativeName('en'), 'English')
+  })
 })
 
 describe('getLanguageZhName()', function() {
@@ -36,11 +45,17 @@ describe('getLanguageZhName()', function() {
   it('zh-CN', function(){
     assert.equal(LocaleCode.getLanguageZhName('zh-CN'), '中文')
   })
+  it('en', function(){
+    assert.equal(LocaleCode.getLanguageZhName('en'), '英语')
+  })
 })
 
 describe('getLanguages()', function() {
   it('[en-US,zh-CN]', function(){
     assert.deepEqual(LocaleCode.getLanguages(['en-US','zh-CN']), [{code:'en-US', name:'English', nativeName:'English', zhName:'英语'}, {code:'zh-CN', name:'Chinese', nativeName:'中文', zhName:'中文'}])
+  })
+  it('[en,zh]', function(){
+    assert.deepEqual(LocaleCode.getLanguages(['en','zh']), [{code:'en', name:'English', nativeName:'English', zhName:'英语'}, {code:'zh', name:'Chinese', nativeName:'中文', zhName:'中文'}])
   })
 })
 
@@ -54,6 +69,12 @@ describe('validateLanguageCode()', function() {
   it('bb-XX', function(){
     assert.equal(LocaleCode.validateLanguageCode('bb-XX'), false)
   })
+  it('en', function(){
+    assert.equal(LocaleCode.validateLanguageCode('en'), true)
+  })
+  it('bb', function(){
+    assert.equal(LocaleCode.validateLanguageCode('bb'), false)
+  })
 })
 
 
@@ -64,6 +85,9 @@ describe('getCountryCode()', function() {
   it('zh-US', function(){
     assert.equal(LocaleCode.getCountryCode('zh-CN'), 'CN')
   })
+  it('en', function(){
+    assert.equal(LocaleCode.getCountryCode('en'), null)
+  })
 })
 
 describe('getCountryName()', function() {
@@ -72,6 +96,9 @@ describe('getCountryName()', function() {
   })
   it('zh-CN', function(){
     assert.equal(LocaleCode.getCountryName('zh-CN'), 'China')
+  })
+  it('en', function(){
+    assert.equal(LocaleCode.getCountryName('en'), null)
   })
 })
 
@@ -84,6 +111,12 @@ describe('validateCountryCode()', function() {
   })
   it('bb-XX', function(){
     assert.equal(LocaleCode.validateCountryCode('bb-XX'), false)
+  })
+  it('US', function(){
+    assert.equal(LocaleCode.validateCountryCode('US'), false)
+  })
+  it('bb', function(){
+    assert.equal(LocaleCode.validateCountryCode('bb'), false)
   })
 })
 
@@ -100,5 +133,10 @@ describe('validate()', function() {
   it('bb-XX', function(){
     assert.equal(LocaleCode.validate('bb-XX'), false)
   })
+  it('en', function(){
+    assert.equal(LocaleCode.validate('en'), true)
+  })
+  it('bb', function(){
+    assert.equal(LocaleCode.validate('bb'), false)
+  })
 })
-


### PR DESCRIPTION
Add functionality to access ISO-639-1 language code with or without the country code.